### PR TITLE
feat(web): add tailwind with custom colors

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,9 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^4.1.12",
     "vite": "^5.0.0"
   }
 }

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -12,23 +12,29 @@ export default function App() {
   }, []);
 
   return (
-    <main style={{ fontFamily: "system-ui", padding: 24 }}>
-      <h1>BaselineMind (Monorepo)</h1>
-      <p>React + Node (Express) — basic starter</p>
+    <main className="font-sans p-6">
+      <h1 className="text-2xl font-bold text-primary">BaselineMind (Monorepo)</h1>
+      <p className="text-secondary">React + Node (Express) — basic starter</p>
 
-      <section style={{ marginTop: 24 }}>
-        <h3>API Health</h3>
-        <code>{JSON.stringify(health, null, 2) || "loading..."}</code>
+      <section className="mt-6">
+        <h3 className="text-lg font-semibold">API Health</h3>
+        <pre className="mt-2 bg-surface p-2 rounded">
+          {JSON.stringify(health, null, 2) || "loading..."}
+        </pre>
       </section>
 
-      <section style={{ marginTop: 24 }}>
-        <h3>Greeting</h3>
-        <code>{JSON.stringify(greet, null, 2) || "loading..."}</code>
+      <section className="mt-6">
+        <h3 className="text-lg font-semibold">Greeting</h3>
+        <pre className="mt-2 bg-surface p-2 rounded">
+          {JSON.stringify(greet, null, 2) || "loading..."}
+        </pre>
       </section>
 
-      <section style={{ marginTop: 24 }}>
-        <h3>Current Time</h3>
-        <code>{JSON.stringify(time, null, 2) || "loading..."}</code>
+      <section className="mt-6">
+        <h3 className="text-lg font-semibold">Current Time</h3>
+        <pre className="mt-2 bg-surface p-2 rounded">
+          {JSON.stringify(time, null, 2) || "loading..."}
+        </pre>
       </section>
     </main>
   );

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-background text-gray-900;
+}

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.jsx";
+import "./index.css";
 
 createRoot(document.getElementById("root")).render(<App />);

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,0 +1,17 @@
+export default {
+  content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        primary: "#2563eb",    // calm blue
+        secondary: "#10b981",  // emerald green
+        accent: "#0ea5e9",     // sky blue accent
+        warning: "#f59e0b",    // amber
+        danger: "#ef4444",     // red
+        background: "#f8fafc", // slate-50
+        surface: "#ffffff"     // white surface
+      }
+    }
+  },
+  plugins: [],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,9 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.2.0",
+        "autoprefixer": "^10.4.21",
+        "postcss": "^8.5.6",
+        "tailwindcss": "^4.1.12",
         "vite": "^5.0.0"
       }
     },
@@ -1221,6 +1224,44 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2014,6 +2055,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
       }
     },
     "node_modules/fresh": {
@@ -2946,6 +3001,16 @@
         "validate-npm-package-license": "^3.0.1"
       }
     },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm-run-all": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
@@ -3181,6 +3246,13 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -3897,6 +3969,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.12.tgz",
+      "integrity": "sha512-DzFtxOi+7NsFf7DBtI3BJsynR+0Yp6etH+nRPTbpWnS2pZBaSksv/JGctNwSWzbFjp0vxSqknaUylseZqMDGrA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",


### PR DESCRIPTION
## Summary
- set up Tailwind CSS in the web app
- add calming custom color palette for primary, secondary, accent, warning, danger, background, and surface
- apply Tailwind classes to existing components and wire up index.css

## Testing
- `npm test` (fails: Missing script: "test")
- `npm --workspace apps/web run build` (fails: Missing script: "build")

------
https://chatgpt.com/codex/tasks/task_e_68af3125ec38832aa1ba32867dc04f8f