### PR TITLE
feat(web): add dashboard home page

### DIFF
--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,41 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
+import Dashboard from "./components/Dashboard";
 
 export default function App() {
-  const [health, setHealth] = useState(null);
-  const [greet, setGreet] = useState(null);
-  const [time, setTime] = useState(null);
-
-  useEffect(() => {
-    fetch("/api/health").then(r => r.json()).then(setHealth);
-    fetch("/api/greet?name=BaselineMind").then(r => r.json()).then(setGreet);
-    fetch("/api/time").then(r => r.json()).then(setTime);
-  }, []);
-
-  return (
-    <main className="font-sans p-6">
-      <h1 className="text-2xl font-bold text-primary">BaselineMind (Monorepo)</h1>
-      <p className="text-secondary">React + Node (Express) — basic starter</p>
-
-      <section className="mt-6">
-        <h3 className="text-lg font-semibold">API Health</h3>
-        <pre className="mt-2 bg-surface p-2 rounded">
-          {JSON.stringify(health, null, 2) || "loading..."}
-        </pre>
-      </section>
-
-      <section className="mt-6">
-        <h3 className="text-lg font-semibold">Greeting</h3>
-        <pre className="mt-2 bg-surface p-2 rounded">
-          {JSON.stringify(greet, null, 2) || "loading..."}
-        </pre>
-      </section>
-
-      <section className="mt-6">
-        <h3 className="text-lg font-semibold">Current Time</h3>
-        <pre className="mt-2 bg-surface p-2 rounded">
-          {JSON.stringify(time, null, 2) || "loading..."}
-        </pre>
-      </section>
-    </main>
-  );
+  return <Dashboard />;
 }
+

--- a/apps/web/src/components/Dashboard.jsx
+++ b/apps/web/src/components/Dashboard.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+
+const HABIT_OPTIONS = ["Sleep", "Exercise", "Nutrition", "Mindfulness", "Work"];
+
+export default function Dashboard() {
+  const [selectedLoops, setSelectedLoops] = useState([]);
+  const [baseline, setBaseline] = useState(50);
+
+  const toggleLoop = (loop) => {
+    setSelectedLoops((prev) =>
+      prev.includes(loop) ? prev.filter((l) => l !== loop) : [...prev, loop]
+    );
+  };
+
+  return (
+    <main className="p-6 font-sans">
+      <h1 className="text-2xl font-bold text-primary">Your Dashboard</h1>
+
+      <section className="mt-6">
+        <h2 className="text-lg font-semibold">Top Habit Loops</h2>
+        <div className="mt-2 grid grid-cols-2 gap-2">
+          {HABIT_OPTIONS.map((loop) => (
+            <label key={loop} className="flex items-center space-x-2">
+              <input
+                type="checkbox"
+                checked={selectedLoops.includes(loop)}
+                onChange={() => toggleLoop(loop)}
+              />
+              <span>{loop}</span>
+            </label>
+          ))}
+        </div>
+        {selectedLoops.length > 0 && (
+          <p className="mt-2 text-sm text-secondary">
+            Selected: {selectedLoops.join(", ")}
+          </p>
+        )}
+      </section>
+
+      <section className="mt-6">
+        <h2 className="text-lg font-semibold">Baseline Level</h2>
+        <div className="mt-2 flex items-center space-x-4">
+          <input
+            type="range"
+            min="0"
+            max="100"
+            value={baseline}
+            onChange={(e) => setBaseline(Number(e.target.value))}
+            className="w-full"
+          />
+          <span className="font-medium">{baseline}</span>
+        </div>
+      </section>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- replace sample app with dashboard
- allow selecting top habit loops
- show adjustable baseline level

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af33a27478832a9f2be7fc5eec6357